### PR TITLE
Fall back to alternate content-length header

### DIFF
--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -1061,6 +1061,10 @@ class InstagramScraper(object):
                                             downloaded = 0
                                             media_file.seek(0)
                                         content_length = response.headers.get('Content-Length')
+
+                                        if content_length is None:
+                                            content_length = response.headers.get('x-full-image-content-length')
+
                                         if content_length is None:
                                             self.logger.warning('No Content-Length in response, the file {0} may be partially downloaded'.format(base_name))
                                         else:


### PR DESCRIPTION
Recently I've been getting a lot of these warnings:

```
WARNING: No Content-Length in response, the file [snip].jpg may be partially downloaded
```

often for what seems like every single file.  I took a look at the response in question, and it was indeed missing the `Content-Length` header, but it did include one called `x-full-image-content-length`.  Presumably that serves the same purpose (not sure why they decided to use a non-standard header), so this checks for that header if the standard one is missing.