### PR TITLE
If JSON parse fails, parse as HTML

### DIFF
--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -610,7 +610,12 @@ class InstagramScraper(object):
             try:
                 return json.loads(resp)['graphql']['shortcode_media']
             except ValueError:
-                self.logger.warning('Failed to get media details for ' + shortcode)
+                # Response wasn't JSON, so maybe it was an HTML page.
+                data = resp.split("window.__additionalDataLoaded(")[1].split("});</script>")[0].split('{"graphql":')[1]
+                try:
+                    return json.loads(data)['shortcode_media']
+                except ValueError:
+                    self.logger.warning('Failed to get media details for ' + shortcode)
 
         else:
             self.logger.warning('Failed to get media details for ' + shortcode)


### PR DESCRIPTION
Recently I've been getting some `Failed to get media details` warnings for some posts.  When I looked at the response, it appeared to be an HTML page instead of the expected JSON result.

This uses a similar hack as elsewhere in the script to get the data from the JavaScript variable, if the attempt to parse the entire page as JSON doesn't work.

I *think* this should work (and it does at least fix the warning), but I'm less certain about this than the other PR I just opened.  Let me know if this doesn't do what I think it does.