### PR TITLE
[FIX]: remove dup. & out-of-date posts for metadata w/ --latest-stamps #525

### DIFF
--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -495,7 +495,6 @@ class InstagramScraper(object):
                             pass
                         else:
                             self.posts.append(item)
-                        
                             
                     iter = iter + 1
                     if self.maximum != 0 and iter >= self.maximum:
@@ -1300,12 +1299,10 @@ class InstagramScraper(object):
                 place['location'].get('lat'),
                 place['location'].get('lng')
             ))
-            
-            
+
     def merge_json(self, data, dst='./'):
         if not os.path.exists(dst):
             self.save_json(data, dst)
-
         if data:
             merged = data
             with open(dst, 'rb') as f:

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -19,7 +19,6 @@ import textwrap
 import time
 import xml.etree.ElementTree as ET
 import moviepy.editor as mpe
-from collections import Counter
 
 try:
     from urllib.parse import urlparse
@@ -1315,14 +1314,16 @@ class InstagramScraper(object):
 
     @staticmethod
     def remove_duplicate_data(file_data):
-        duplicate_post_index = []
+        unique_ids = set()
         file_data_ids = []
         for post in file_data:
             file_data_ids.append(post["id"])
-        file_data_id_counts = Counter(file_data_ids)
-        for id_, count in file_data_id_counts.items():
-            if count > 1:
-                file_data.pop(file_data_ids.index(id_))
+        file_ids_copy = file_data_ids.copy()
+        for id_ in file_ids_copy:
+            if id_ in unique_ids:
+                file_data_ids.pop(file_data_ids.index(id_))
+            else:
+                unique_ids.add(id_)
             
     @staticmethod
     def save_json(data, dst='./'):


### PR DESCRIPTION
Fix #525  bug that allows duplicate post metadata by comparing the ID of the posts before saving them to json. Ensure the posts we saved are newer than the timestamp provided by --latest-stamps arg. If this arg is not used then all posts collected are saved.