### PR TITLE
docs: fix simple typo, locaiton -> location

### DIFF
--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -1407,7 +1407,7 @@ class InstagramScraper(object):
     @staticmethod
     def get_locations_from_file(locations_file):
         """
-        parse an ini like file with sections composed of headers, [locaiton],
+        parse an ini like file with sections composed of headers, [location],
         and arguments that are location ids
         """
         locations={}


### PR DESCRIPTION
There is a small typo in instagram_scraper/app.py.

Should read `location` rather than `locaiton`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md