### PR TITLE
Added way to collect stories metadata without downloading video/images

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -24,3 +24,4 @@ instagram-scraper is written and maintained by Richard Arcega, along with the fo
 - Alexander Nikolaev ([@AlexNik](https://github.com/AlexNik))
 - Kevin Surya ([@kevinsudut](https://github.com/kevinsudut))
 - Ibrahim Mousa ([@ibrahim-mousa](https://github.com/ibrahim-mousa))
+- Artur-Yurii Korchynskyi ([@akorchyn](https://github.com/akorchyn))

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -783,7 +783,7 @@ class InstagramScraper(object):
     def get_stories(self, dst, executor, future_to_item, user, username):
         """Scrapes the user's stories."""
         if self.logged_in and \
-                ('story-image' in self.media_types or 'story-video' in self.media_types):
+                ('story-image' in self.media_types or 'story-video' in self.media_types or 'none' in self.media_types):
             # Get the user's stories.
             all_stories = []
             all_stories.extend(self.fetch_main_stories(user['id']))


### PR DESCRIPTION
Hi, the Instagram scraper has the functionality to avoid downloading content if we provide the none argument to media types.
Unfortunately, it worked only with post data and avoided stories data. I think we have to get full metadata including stories when we request none.

Please, take a look.
Relates: [Issue 644](https://github.com/arc298/instagram-scraper/issues/644)