### PR TITLE
Fix GraphQL error properly, make the app work again

### DIFF
--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -605,7 +605,16 @@ class InstagramScraper(object):
                         urls += self.augment_node(carousel_item['node'])['urls']
                     node['urls'] = urls
                 else:
-                    node['urls'] = [self.get_original_image(details['display_url'])]
+                    try:
+                        node['urls'] = [self.get_original_image(details['display_url'])]
+                    except KeyError:
+                        for media in (details['carousel_media'] if 'carousel_media' in details else [details]):
+                            if media['media_type'] == 1:
+                                media_versions = media['image_versions2']['candidates']
+                            elif media['media_type'] == 2:
+                                media_versions = media['video_versions']
+
+                            node['urls'].append(media_versions[0]['url'])
 
         return node
 
@@ -622,7 +631,8 @@ class InstagramScraper(object):
                     return self._get_json(data)['shortcode_media']
                 except ValueError:
                     self.logger.warning('Failed to get media details for ' + shortcode)
-
+            except KeyError:
+                return self._get_json(resp)['items'][0]
         else:
             self.logger.warning('Failed to get media details for ' + shortcode)
 


### PR DESCRIPTION
Recently, Instagram pushed an API update to many users that broke instagram-scraper with GraphQL errors. @novitae proposed a fix a while back in pull request https://github.com/arc298/instagram-scraper/pull/742 but it actually does not work and silently swallows video posts in the process.

I have tested on several accounts and the error is gone.

This fixes https://github.com/arc298/instagram-scraper/issues/739
Pull request https://github.com/arc298/instagram-scraper/pull/742 is obsolete.