### PR TITLE
prevent EOFError for pickle opening an empty/new cookiejar

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,3 +25,4 @@ instagram-scraper is written and maintained by Richard Arcega, along with the fo
 - Kevin Surya ([@kevinsudut](https://github.com/kevinsudut))
 - Ibrahim Mousa ([@ibrahim-mousa](https://github.com/ibrahim-mousa))
 - Artur-Yurii Korchynskyi ([@akorchyn](https://github.com/akorchyn))
+- Brian Barnes-Cocke ([@babarnescocke](https://github.com/babarnescocke))

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -139,7 +139,7 @@ class InstagramScraper(object):
             raise
 
         self.session.headers = {'user-agent': CHROME_WIN_UA}
-        if self.cookiejar and os.path.exists(self.cookiejar):
+        if self.cookiejar and os.path.exists(self.cookiejar) and os.path.getsize(self.cookiejar) > 0:
             with open(self.cookiejar, 'rb') as f:
                 self.session.cookies.update(pickle.load(f))
         self.session.cookies.set('ig_pr', '1')


### PR DESCRIPTION
I had difficulty getting instagram-scraper to reliably work with just username and password, in trying to get it to work with the `--cookiejar` flag I found a logic problem in control flow.  In debugging, it `python3 -m pdb /usr/lib/python3.9/site-packages/instagram_scraper/app.py [params],` I would get EOFError panics from 'pickle' trying to set self.session.cookies to a blank file. The PR is to check if the file is empty, if the file is empty pickle doesn't need to read from it.