### PR TITLE
Urgent: don't swallow WEBP posts

### DIFF
--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -1010,7 +1010,7 @@ class InstagramScraper(object):
         })
 
     def has_selected_media_types(self, item):
-        filetypes = {'jpg': 0, 'mp4': 0}
+        filetypes = {'jpg': 0, 'mp4': 0, 'webp': 0}
 
         for url in item['urls']:
             ext = self.__get_file_ext(url)
@@ -1018,7 +1018,7 @@ class InstagramScraper(object):
                 filetypes[ext] = 0
             filetypes[ext] += 1
 
-        if ('image' in self.media_types and filetypes['jpg'] > 0) or \
+        if ('image' in self.media_types and (filetypes['jpg'] > 0 or filetypes['webp'] > 0)) or \
                 ('video' in self.media_types and filetypes['mp4'] > 0):
             return True
 


### PR DESCRIPTION
I noticed today that some posts weren't being downloaded. It was weird because they were obviously new and `augment_node` was finding URLs correctly.

Apparently you can choose which media to download (image or video) and somebody hardcoded images to be `JPG` extension only. Instagram recently started pushing the `WEBP` format for images, which resulted in posts containing `WEBP` being silently swallowed, because according to that method, `webp` is neither image nor video.

@AlexNik please release this ASAP, currently there is a data loss as Instagram is rolling out the WEBP format to new users.

If you use the `--latest` option, you should redownload your posts (or at least any post newer than 2021). You can do this by setting all entries in your `latest` file to timestamp `1640995200` or just re-downloading all posts without the `--latest` option.