### PR TITLE
Don't swallow media with `--latest` if there are pinned posts

### DIFF
--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -937,9 +937,17 @@ class InstagramScraper(object):
         if media:
             try:
                 while True:
+                    idx = 0
+
                     for item in media:
                         if not self.is_new_media(item):
-                            return
+                            # Verify if the order is chronological and there are
+                            # no pinned posts from this point forward
+                            timestamps = [self.__get_timestamp(item) for item in media[idx:]]
+
+                            if sorted(timestamps, reverse=True) == timestamps:
+                                return
+                        idx += 1
                         yield item
 
                     if end_cursor:
@@ -987,6 +995,7 @@ class InstagramScraper(object):
         for url in item['urls']:
             ext = self.__get_file_ext(url)
             if ext not in filetypes:
+                self.logger.warning('Unknown file type: {0} for {1}'.format(ext, url))
                 filetypes[ext] = 0
             filetypes[ext] += 1
 


### PR DESCRIPTION
Instagram recently added a new feature where you can pin some posts so they appear in the front. That messes up `query_media_gen` when you use the `--latest` option because it stops yielding from the generator once it encounters a post that is not new, as it expects the response to be in a reverse chronological order. If there's a pinned post that is older than the latest timestamp, it completely blocks the scraper from downloading anything.

Note that this does not in fact download stale posts because the timestamp is checked again in https://github.com/arc298/instagram-scraper/blob/62672127ddaa0ac3c3c64a57022ef0024e716ffe/instagram_scraper/app.py#L845

If you use `--latest` option, you should either redownload everything or set timestamps to maybe `1654041600`. Stories are not affected.